### PR TITLE
Fixed Firefox Quantum redirecting to opera instead

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -1401,7 +1401,7 @@
       "img": "https://ph-files.imgix.net/e87d9d47-06a2-4359-a61b-38e33b7171f6?auto=format&auto=compress&codec=mozjpeg&cs=strip&w=608&h=380&fit=max",
       "name": "Firefox Quantum",
       "desc": "The newest Firefox Engine, the fastest version of Firefox yet. 🔥🦊",
-      "url": "https://opera.com",
+      "url": "https://www.mozilla.org/en-GB/firefox/browsers/quantum/",
       "pricing": "Free Forever",
       "category": "Browsers",
       "makers": [ 


### PR DESCRIPTION
As the title suggests, it used to redirect to opera but now it redirects to Firefox Quantum's website